### PR TITLE
Upgrade project: fix bugs, improve WiGLE compliance, add new features

### DIFF
--- a/esp32-gps-wifi-wigle.ino
+++ b/esp32-gps-wifi-wigle.ino
@@ -1,3 +1,16 @@
+/*
+ * esp32-gps-wifi-wigle — GPS + WiFi wardriving logger for WiGLE.net
+ *
+ * Required libraries (Arduino IDE Library Manager or arduino-cli lib install):
+ *   TinyGPSPlus          by Mikal Hart     >= 1.0.3
+ *   Adafruit GFX Library by Adafruit       >= 1.11.9
+ *   Adafruit SSD1306     by Adafruit       >= 2.5.9
+ *   RTClib               by Adafruit       >= 2.1.4
+ *
+ * Built-in to ESP32 Arduino core (no separate install needed):
+ *   WiFi, SD, SPI, Wire, HardwareSerial
+ */
+
 #include <TinyGPSPlus.h>
 #include <HardwareSerial.h>
 #include <WiFi.h>
@@ -12,114 +25,136 @@
 // RTC setup
 RTC_Millis rtc;
 
-// Pin definitions for GPS module
+// Pin definitions
 static const int RXPin = 16, TXPin = 17;
-static const uint32_t GPSBaud = 9600;  // GPS module baud rate
+static const uint32_t GPSBaud = 9600;
 
-// OLED display setup
-#define SCREEN_WIDTH 128
-#define SCREEN_HEIGHT 64
-#define OLED_RESET -1
-#define SD_CS_PIN 5       // Chip select pin for SD card
-#define MIN_SATELLITES 4  // Minimum number of satellites for a valid GPS fix
-#define PST_OFFSET -8     // PST is UTC-8
+// Display & hardware constants
+#define SCREEN_WIDTH    128
+#define SCREEN_HEIGHT   64
+#define OLED_RESET      -1
+#define SD_CS_PIN       5
+#define LED_PIN         2     // built-in LED on most ESP32 DevKit boards
+#define MIN_SATELLITES  4
+#define PST_OFFSET      -8    // defined for reference; timestamps are logged as UTC
+#define SCAN_INTERVAL_MS 15000
 
-// Objects for GPS, serial communication, display, and SD card
+// Objects
 TinyGPSPlus gps;
 HardwareSerial gpsSerial(1);
 Adafruit_SSD1306 display(SCREEN_WIDTH, SCREEN_HEIGHT, &Wire, OLED_RESET);
 File csvFile;
 
-// Counters for WiFi scans and networks found
-int scanCount = 0;
-int networkCount = 0;
+// State
+int scanCount     = 0;
+int networkCount  = 0;       // networks found in the most recent scan
+int totalNetworks = 0;       // cumulative networks across all scans
+char csvFilename[32] = "";   // timestamped filename persisted across functions
+bool systemReady  = false;   // true only after all hardware initialises successfully
+
+// ─── setup / loop ────────────────────────────────────────────────────────────
 
 void setup() {
-  Serial.begin(115200); // Start serial communication for debugging
-  gpsSerial.begin(GPSBaud, SERIAL_8N1, RXPin, TXPin); // Start GPS serial communication
-  delay(5000); // Allow time for the system to stabilize
+  Serial.begin(115200);
+  pinMode(LED_PIN, OUTPUT);
+  digitalWrite(LED_PIN, LOW);
 
-  // Initialize OLED display
+  gpsSerial.begin(GPSBaud, SERIAL_8N1, RXPin, TXPin);
+  delay(5000);
+
   if (!display.begin(SSD1306_SWITCHCAPVCC, 0x3C)) {
     Serial.println(F("SSD1306 allocation failed"));
-    for (;;); // Infinite loop if display initialization fails
+    for (;;);
   }
   display.display();
   delay(2000);
   display.clearDisplay();
 
-  // Initialize SD card
   if (!SD.begin(SD_CS_PIN)) {
     Serial.println("Card failed, or not present");
     displayError("SD Card Error");
+    digitalWrite(LED_PIN, HIGH);
     return;
   }
 
-  // Initialize CSV file
   if (!initializeCSV()) {
     displayError("CSV Init Error");
+    digitalWrite(LED_PIN, HIGH);
     return;
   }
 
-  rtc.begin(DateTime(F(__DATE__), F(__TIME__))); // Initialize RTC with compile time
-
-  Serial.println(F("GPS and WiFi Scanner"));
+  rtc.begin(DateTime(F(__DATE__), F(__TIME__)));
+  systemReady = true;
+  Serial.println(F("GPS and WiFi Scanner ready"));
 }
 
 void loop() {
-  // Read GPS data
+  if (!systemReady) return;
+
   while (gpsSerial.available() > 0) {
     gps.encode(gpsSerial.read());
   }
 
-  // Check if GPS data is valid
-  if (gps.location.isValid() && gps.hdop.isValid() && gps.date.isValid() && gps.time.isValid() && gps.satellites.value() >= MIN_SATELLITES) {
-    // Update RTC with GPS time
-    DateTime gpsTime(gps.date.year(), gps.date.month(), gps.date.day(), gps.time.hour(), gps.time.minute(), gps.time.second());
+  if (gps.location.isValid() && gps.hdop.isValid() &&
+      gps.date.isValid()     && gps.time.isValid() &&
+      gps.satellites.value() >= MIN_SATELLITES) {
+
+    DateTime gpsTime(gps.date.year(), gps.date.month(), gps.date.day(),
+                     gps.time.hour(), gps.time.minute(), gps.time.second());
     rtc.adjust(gpsTime);
 
-    // Display GPS data and scan for WiFi networks
     displayGPSData();
+    blinkLED(3, 100, 100);   // fast triple blink = scan starting
     scanWiFiNetworks();
     displayGPSData();
-    delay(15000); // Wait 15 seconds before next scan
+    delay(SCAN_INTERVAL_MS);
   } else {
     displaySearching();
   }
 }
 
-// Display GPS data on the OLED screen
+// ─── display helpers ─────────────────────────────────────────────────────────
+
 void displayGPSData() {
   display.clearDisplay();
   display.setTextSize(1);
   display.setTextColor(SSD1306_WHITE);
   display.setCursor(0, 0);
+
   display.print("Lat: ");
   display.println(gps.location.lat(), 6);
   display.print("Lng: ");
   display.println(gps.location.lng(), 6);
   display.print("Alt: ");
   display.println(gps.altitude.meters());
-  display.print("Sat: ");
-  display.println(gps.satellites.value());
 
-  // Get the current time from RTC and display it
+  // Combine sat count and speed on one line to keep the display to 7 rows
+  display.print("Sat:");
+  display.print(gps.satellites.value());
+  display.print(" Spd:");
+  if (gps.speed.isValid()) {
+    display.print(gps.speed.kmph(), 1);
+    display.println("k");
+  } else {
+    display.println("--");
+  }
+
   DateTime now = rtc.now();
-  char buffer[30];
-  snprintf(buffer, sizeof(buffer), "%04d-%02d-%02d %02d:%02d:%02d", now.year(), now.month(), now.day(), now.hour(), now.minute(), now.second());
+  char timebuf[20];
+  snprintf(timebuf, sizeof(timebuf), "%04d-%02d-%02d %02d:%02d:%02d",
+           now.year(), now.month(), now.day(),
+           now.hour(), now.minute(), now.second());
   display.print("Time: ");
-  display.println(buffer);
+  display.println(timebuf);
 
-  // Display the number of networks found and scan count
   display.print("Nets: ");
-  display.println(networkCount);
+  display.println(totalNetworks);
   display.print("Scans: ");
   display.println(scanCount);
 
   display.display();
 }
 
-// Display a message while searching for GPS signal
 void displaySearching() {
   display.clearDisplay();
   display.setTextSize(1);
@@ -129,9 +164,9 @@ void displaySearching() {
   display.print("Satellites: ");
   display.println(gps.satellites.value());
   display.display();
+  blinkLED(1, 500, 500);   // slow single blink = waiting for GPS fix
 }
 
-// Display an error message on the OLED screen
 void displayError(const char* error) {
   display.clearDisplay();
   display.setTextSize(1);
@@ -141,27 +176,143 @@ void displayError(const char* error) {
   display.display();
 }
 
-// Initialize a new CSV file for storing WiFi scan results
-bool initializeCSV() {
-  DateTime now = rtc.now();
-  char filename[32];
-  snprintf(filename, sizeof(filename), "/wigle_%04d%02d%02d_%02d%02d%02d.csv", now.year(), now.month(), now.day(), now.hour(), now.minute(), now.second());
-  csvFile = SD.open(filename, FILE_WRITE);
-  if (csvFile) {
-    csvFile.println("BSSID,SSID,Capabilities,First timestamp seen,Channel,Frequency,RSSI,Latitude,Longitude,Altitude,Accuracy,RCOIs,MfgrId,Type");
-    csvFile.close();
-    return true;
+// ─── utility helpers ─────────────────────────────────────────────────────────
+
+void blinkLED(int count, int on_ms, int off_ms) {
+  for (int i = 0; i < count; i++) {
+    digitalWrite(LED_PIN, HIGH);
+    delay(on_ms);
+    digitalWrite(LED_PIN, LOW);
+    delay(off_ms);
   }
-  return false;
 }
 
-// Scan for WiFi networks and store results in the CSV file
+// Correct 802.11 channel → frequency mapping for 2.4 GHz and 5 GHz
+int channelToFrequency(int channel) {
+  if (channel >= 1 && channel <= 13) return 2407 + channel * 5;
+  if (channel == 14)                 return 2484;
+  if (channel >= 36)                 return 5000 + channel * 5;
+  return 0;
+}
+
+// WiGLE-compatible AuthMode string derived from the ESP32 encryption type
+String getAuthMode(wifi_auth_mode_t authType) {
+  switch (authType) {
+    case WIFI_AUTH_OPEN:            return "[ESS]";
+    case WIFI_AUTH_WEP:             return "[WEP][ESS]";
+    case WIFI_AUTH_WPA_PSK:         return "[WPA-PSK-CCMP][ESS]";
+    case WIFI_AUTH_WPA2_PSK:        return "[WPA2-PSK-CCMP][ESS]";
+    case WIFI_AUTH_WPA_WPA2_PSK:    return "[WPA-PSK-CCMP][WPA2-PSK-CCMP][ESS]";
+    case WIFI_AUTH_WPA2_ENTERPRISE: return "[WPA2-EAP-CCMP][ESS]";
+    case WIFI_AUTH_WPA3_PSK:        return "[WPA3-SAE-CCMP][ESS]";
+    case WIFI_AUTH_WPA2_WPA3_PSK:   return "[WPA2-PSK-CCMP][WPA3-SAE-CCMP][ESS]";
+    default:                        return "[ESS]";
+  }
+}
+
+// RFC 4180: double any embedded quotes; strip bare newlines
+String sanitizeSSID(const String& ssid) {
+  String out;
+  out.reserve(ssid.length());
+  for (int i = 0; i < (int)ssid.length(); i++) {
+    char c = ssid.charAt(i);
+    if (c == '"')            out += "\"\"";
+    else if (c == '\n' || c == '\r') out += ' ';
+    else                     out += c;
+  }
+  return out;
+}
+
+const char* hdopQuality(float hdop) {
+  if (hdop <= 1.0f)  return "Ideal";
+  if (hdop <= 2.0f)  return "Excellent";
+  if (hdop <= 5.0f)  return "Good";
+  if (hdop <= 10.0f) return "Moderate";
+  if (hdop <= 20.0f) return "Fair";
+  return "Poor";
+}
+
+String getLocalTimestamp() {
+  DateTime now = rtc.now();
+  char buf[20];
+  snprintf(buf, sizeof(buf), "%04d-%02d-%02d %02d:%02d:%02d",
+           now.year(), now.month(), now.day(),
+           now.hour(), now.minute(), now.second());
+  return String(buf);
+}
+
+// ─── CSV / SD helpers ────────────────────────────────────────────────────────
+
+bool initializeCSV() {
+  DateTime now = rtc.now();
+  snprintf(csvFilename, sizeof(csvFilename), "/wigle_%04d%02d%02d_%02d%02d%02d.csv",
+           now.year(), now.month(), now.day(),
+           now.hour(), now.minute(), now.second());
+
+  csvFile = SD.open(csvFilename, FILE_WRITE);
+  if (!csvFile) return false;
+
+  // WiGLE 1.4 format: device descriptor line followed by column header line
+  csvFile.println(
+    "WigleWifi-1.4,appRelease=2.26,model=ESP32,release=1.0.0,"
+    "device=ESP32-Wardriver,display=OLED,board=ESP32,brand=Espressif"
+  );
+  csvFile.println(
+    "MAC,SSID,AuthMode,FirstSeen,Channel,Frequency,RSSI,"
+    "CurrentLatitude,CurrentLongitude,AltitudeMeters,AccuracyMeters,Type"
+  );
+  csvFile.close();
+  return true;
+}
+
+void writeNetworkData(int idx) {
+  String bssid    = WiFi.BSSIDstr(idx);
+  String ssid     = sanitizeSSID(WiFi.SSID(idx));
+  String authMode = getAuthMode(WiFi.encryptionType(idx));
+  String ts       = getLocalTimestamp();
+  int    channel  = WiFi.channel(idx);
+  int    freq     = channelToFrequency(channel);
+  int    rssi     = WiFi.RSSI(idx);
+
+  csvFile.print("\""); csvFile.print(bssid);    csvFile.print("\",");
+  csvFile.print("\""); csvFile.print(ssid);     csvFile.print("\",");
+  csvFile.print("\""); csvFile.print(authMode); csvFile.print("\",");
+  csvFile.print("\""); csvFile.print(ts);       csvFile.print("\",");
+  csvFile.print(channel);   csvFile.print(",");
+  csvFile.print(freq);      csvFile.print(",");
+  csvFile.print(rssi);      csvFile.print(",");
+  csvFile.print(gps.location.lat(), 6); csvFile.print(",");
+  csvFile.print(gps.location.lng(), 6); csvFile.print(",");
+  csvFile.print(gps.altitude.meters()); csvFile.print(",");
+  csvFile.print(gps.hdop.hdop());       csvFile.print(",");
+  csvFile.println("WIFI");
+}
+
 void scanWiFiNetworks() {
-  networkCount = WiFi.scanNetworks(); // Scan for WiFi networks
-  scanCount++; // Increment scan count
-  csvFile = SD.open("/wigle.csv", FILE_APPEND);
+  networkCount = WiFi.scanNetworks();
+  scanCount++;
+  totalNetworks += networkCount;
+
+  // Print to serial while scan buffer is still valid
+  Serial.print("Scan #"); Serial.println(scanCount);
+  Serial.print("Networks found: "); Serial.println(networkCount);
+  Serial.print("HDOP: ");
+  Serial.print(gps.hdop.hdop(), 2);
+  Serial.print(" ("); Serial.print(hdopQuality(gps.hdop.hdop())); Serial.println(")");
+
+  for (int i = 0; i < networkCount; i++) {
+    Serial.print("  ["); Serial.print(i + 1); Serial.print("]");
+    Serial.print(" SSID:");   Serial.print(WiFi.SSID(i));
+    Serial.print(" BSSID:");  Serial.print(WiFi.BSSIDstr(i));
+    Serial.print(" CH:");     Serial.print(WiFi.channel(i));
+    Serial.print(" RSSI:");   Serial.print(WiFi.RSSI(i));
+    Serial.println("dBm");
+  }
+
+  // Write CSV while scan buffer is still valid
+  csvFile = SD.open(csvFilename, FILE_APPEND);
   if (csvFile) {
-    for (int i = 0; i < networkCount; ++i) {
+    for (int i = 0; i < networkCount; i++) {
       writeNetworkData(i);
     }
     csvFile.close();
@@ -169,67 +320,6 @@ void scanWiFiNetworks() {
     displayError("CSV Write Error");
   }
 
-  // Print networks to serial monitor
-  Serial.print("Scan #");
-  Serial.println(scanCount);
-  Serial.print("Networks found: ");
-  Serial.println(networkCount);
-  for (int i = 0; i < networkCount; ++i) {
-    Serial.print("Network #");
-    Serial.print(i + 1);
-    Serial.print(": ");
-    Serial.print(WiFi.SSID(i));
-    Serial.print(" (");
-    Serial.print(WiFi.RSSI(i));
-    Serial.println(" dBm)");
-  }
-}
-
-// Write network data to the CSV file
-void writeNetworkData(int networkIndex) {
-  String bssid = WiFi.BSSIDstr(networkIndex);
-  String ssid = WiFi.SSID(networkIndex);
-  String capabilities = WiFi.encryptionType(networkIndex) == WIFI_AUTH_OPEN ? "Open" : "Secured";
-  String timestamp = getLocalTimestamp();
-  int channel = WiFi.channel(networkIndex);
-  int frequency = 2400 + (channel - 1) * 5;  // Assuming 2.4GHz WiFi
-  int rssi = WiFi.RSSI(networkIndex);
-  String latitude = String(gps.location.lat(), 6);
-  String longitude = String(gps.location.lng(), 6);
-  String altitude = String(gps.altitude.meters());
-  String accuracy = String(gps.hdop.hdop());
-  String rcois = "";   // Placeholder if RCOIs is not available
-  String mfgrid = "";  // Placeholder if Manufacturer ID is not available
-  String type = "WiFi";
-
-  // Write network data to CSV file
-  csvFile.print("\"" + bssid + "\",");
-  csvFile.print("\"" + ssid + "\",");
-  csvFile.print("\"" + capabilities + "\",");
-  csvFile.print("\"" + timestamp + "\",");
-  csvFile.print(channel);
-  csvFile.print(",");
-  csvFile.print(frequency);
-  csvFile.print(",");
-  csvFile.print(rssi);
-  csvFile.print(",");
-  csvFile.print(latitude);
-  csvFile.print(",");
-  csvFile.print(longitude);
-  csvFile.print(",");
-  csvFile.print(altitude);
-  csvFile.print(",");
-  csvFile.print(accuracy);
-  csvFile.print(",");
-  csvFile.print("\"" + rcois + "\",");
-  csvFile.print("\"" + mfgrid + "\",");
-  csvFile.println("\"" + type + "\"");
-}
-
-// Get the current timestamp from the RTC
-String getLocalTimestamp() {
-  DateTime now = rtc.now();  // Use RTC time for timestamp
-  char buffer[30];
-  snprintf(buffer, sizeof(buffer), "%04d-%02d-%02d %02d:%02d:%02d", now.year(), now.month(), now.day(), now.hour(), now.minute(), now.second());
-  return String(buffer);
+  // Free heap allocated by WiFi.scanNetworks()
+  WiFi.scanDelete();
 }


### PR DESCRIPTION
Bug fixes:
- Fix CSV dual-file bug: timestamped filename now stored globally so initializeCSV() and scanWiFiNetworks() both use the same file
- Fix frequency calculation: was 2400+(ch-1)*5 (wrong); now uses correct 802.11 formula 2407+ch*5 for 2.4 GHz and 5000+ch*5 for 5 GHz
- Add totalNetworks counter so OLED "Nets:" shows cumulative total instead of resetting each scan
- Call WiFi.scanDelete() after every scan to free heap memory
- Sanitize SSIDs: escape embedded double-quotes (RFC 4180) and strip bare newlines to prevent malformed CSV rows
- Add systemReady flag so a failed SD/CSV init makes loop() a no-op

WiGLE 1.4 compliance:
- CSV now opens with the required WiGLE device descriptor line followed by the standard column headers (MAC, SSID, AuthMode, FirstSeen, etc.)
- AuthMode field now emits proper WiGLE strings ([WPA2-PSK-CCMP][ESS] etc.) instead of the binary "Open"/"Secured" strings
- Remove non-standard RCOIs and MfgrId columns

New features:
- LED_PIN 2 status indicator: solid = init error, slow blink = no GPS fix, fast triple blink = scan starting
- GPS speed shown on OLED alongside satellite count (Sat:N Spd:XX.Xk)
- HDOP quality label printed to serial (Ideal/Excellent/Good/…)
- Serial output per network now includes BSSID and channel
- SCAN_INTERVAL_MS define replaces magic delay(15000)
- Library install comment block at top of file for Arduino IDE / CLI

https://claude.ai/code/session_01Y6WDNDijiUqxsWDDW72gw4